### PR TITLE
Windows: update to GDAL 3.4.1 stack

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,0 @@
-CRT=-ucrt
-include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,8 +1,4 @@
-
-RWINLIB_GDAL = ../windows/gdal3-3.2.1
-RWINLIB_NETCDF = ../windows/netcdf-4.4.1.1-dap
-RWINLIB_SQLITE = ../windows/sqlite-amalgamation-3260000
-
+RWINLIB_GDAL = ../windows/gdal3-3.4.1
 STATLIB = gdalcubes/libgdalcubes.a
 
 LIBGDALCUBES = gdalcubes/src/aggregate_time.o \
@@ -49,9 +45,7 @@ LIBGDALCUBES = gdalcubes/src/aggregate_time.o \
 			multiprocess.o \
 			error.o
 
-PKG_CPPFLAGS = -I$(RWINLIB_GDAL)/include/gdal-3.2.1 \
-               -I$(RWINLIB_GDAL)/include/netcdf-4.7.3 \
-               -I$(RWINLIB_SQLITE) \
+PKG_CPPFLAGS = -I$(RWINLIB_GDAL)/include \
                -DR_PACKAGE -DGDALCUBES_NO_SWARM
  
 TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
@@ -59,15 +53,15 @@ TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
 PKG_LIBS = \
 	-Lgdalcubes -lgdalcubes \
 	-L$(RWINLIB_GDAL)/$(TARGET) \
-	-L$(RWINLIB_GDAL)/lib$(R_ARCH)$(CRT) \
+	-L$(RWINLIB_GDAL)/lib$(R_ARCH) \
 	-lgdal -lsqlite3 -lspatialite -lproj -lgeos_c -lgeos  \
 	-ljson-c -lnetcdf -lmariadbclient -lpq -lpgport -lpgcommon \
 	-lwebp -lcurl -lssh2 -lssl \
 	-lhdf5_hl -lhdf5 -lexpat -lfreexl -lcfitsio \
 	-lmfhdf -lhdf -lxdr -lpcre \
-	-lopenjp2 -ljasper -lpng -ljpeg -ltiff -lgeotiff -lgif -lxml2 -llzma -lz \
+	-lopenjp2 -ljasper -lpng -ljpeg -ltiff -lgeotiff -lgif -lxml2 -llzma -lz -lzstd \
 	-lodbc32 -lodbccp32 -liconv -lpsapi -lwldap32 -lsecur32 -lgdi32 -lnormaliz \
-	-lcrypto -lcrypt32 -lws2_32 -lshlwapi
+	-lcrypto -lcrypt32 -lws2_32 -lshlwapi -lbcrypt
 	
 all: clean winlibs
 	

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -2,19 +2,10 @@ if(getRversion() < "3.3.0") {
   stop("Your version of R is too old. This package requires R-3.3.0 or newer on Windows.")
 }
 
-# For details see: https://github.com/rwinlib/gdal2
-# For details see: https://github.com/rwinlib/netcdf
+# For details see: https://github.com/rwinlib/gdal3
 
-if(!file.exists("../windows/gdal3-3.2.1/include/gdal-3.2.1/gdal.h")){
-  download.file("https://github.com/rwinlib/gdal3/archive/v3.2.1.zip", "lib.zip", quiet = TRUE)
-  dir.create("../windows", showWarnings = FALSE)
-  unzip("lib.zip", exdir = "../windows")
-  unlink("lib.zip")
-}
-
-# previous winlibs come with sqlite library but not with header file
-if(!file.exists("../windows/sqlite-amalgamation-3260000/sqlite3.h")) {
-  download.file("https://www.sqlite.org/2018/sqlite-amalgamation-3260000.zip", "lib.zip", quiet = TRUE)
+if(!file.exists("../windows/gdal3-3.4.1/include/gdal.h")){
+  download.file("https://github.com/rwinlib/gdal3/archive/v3.4.1.zip", "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")


### PR DESCRIPTION
This new version also includes the needed sqlite header, so you don't need to download this separately anymore.